### PR TITLE
Update Word Language Model Example to support default argument weights_only=True

### DIFF
--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -232,7 +232,7 @@ try:
         # Save the model if the validation loss is the best we've seen so far.
         if not best_val_loss or val_loss < best_val_loss:
             with open(args.save, 'wb') as f:
-                torch.save(model, f)
+                torch.save(model.state_dict(), f)
             best_val_loss = val_loss
         else:
             # Anneal the learning rate if no improvement has been seen in the validation dataset.
@@ -243,11 +243,11 @@ except KeyboardInterrupt:
 
 # Load the best saved model.
 with open(args.save, 'rb') as f:
-    model = torch.load(f)
+    model.load_state_dict(torch.load(f))
     # after load the rnn params are not a continuous chunk of memory
     # this makes them a continuous chunk, and will speed up forward pass
     # Currently, only rnn model supports flatten_parameters function.
-    if args.model in ['RNN_TANH', 'RNN_RELU', 'LSTM', 'GRU']:
+    if args.model in ['RNN_TANH', 'RNN_RELU', 'LSTM', 'GRU'] and args.cuda:
         model.rnn.flatten_parameters()
 
 # Run on test data.


### PR DESCRIPTION
Updated example to work with pytorch 2.6+ where weights_only=True is the new default based on this approach https://pytorch.org/tutorials/beginner/saving_loading_models.html

[Line 250](https://github.com/dvrogozh/examples/compare/main...framoncg:word_language_model_example?expand=1#diff-419dae0a76698e7aab1a3a60fcb9bd659919404ed118c0dce884a67e48bb3399R250) adds args.cuda since that line only works if running from cuda https://pytorch.org/docs/stable/generated/torch.nn.RNNBase.html 