### PR TITLE
Use torch.accelerator in DCGAN example

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -17,14 +17,16 @@ jobs:
         python-version: [3.9]
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Dependencies
       run: |
+        export DEBIAN_FRONTEND=noninteractive
+        sudo apt-get update
+        sudo apt install -y git python3-venv make
         echo `python3 --version`
-        sudo apt-get install -y python-setuptools
-        sudo apt-get install -y python3-sphinx
-        python3 -m pip install --upgrade pip
-        python3 -m pip install setuptools
+        python3 -m venv venv 
+        source venv/bin/activate 
+        pip install --upgrade pip setuptools 
       id: build
     - name: Build the docset
       run: | 

--- a/dcgan/README.md
+++ b/dcgan/README.md
@@ -20,31 +20,35 @@ python download.py -c bedroom
 ## Usage
 
 ```
-usage: main.py [-h] --dataset DATASET --dataroot DATAROOT [--workers WORKERS]
-               [--batchSize BATCHSIZE] [--imageSize IMAGESIZE] [--nz NZ]
-               [--ngf NGF] [--ndf NDF] [--niter NITER] [--lr LR]
-               [--beta1 BETA1] [--cuda] [--ngpu NGPU] [--netG NETG]
-               [--netD NETD] [--mps]
+usage: main.py [-h] --dataset DATASET [--dataroot DATAROOT]
+               [--workers WORKERS] [--batchSize BATCHSIZE]
+               [--imageSize IMAGESIZE] [--nz NZ] [--ngf NGF] [--ndf NDF]
+               [--niter NITER] [--lr LR] [--beta1 BETA1] [--dry-run]
+               [--ngpu NGPU] [--netG NETG] [--netD NETD] [--outf OUTF]
+               [--manualSeed MANUALSEED] [--classes CLASSES] [--accel]
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --dataset DATASET     cifar10 | lsun | mnist |imagenet | folder | lfw | fake
   --dataroot DATAROOT   path to dataset
   --workers WORKERS     number of data loading workers
-  --batchSize BATCHSIZE input batch size
-  --imageSize IMAGESIZE the height / width of the input image to network
+  --batchSize BATCHSIZE
+                        input batch size
+  --imageSize IMAGESIZE
+                        the height / width of the input image to network
   --nz NZ               size of the latent z vector
-  --ngf NGF             number of filters in the generator
-  --ndf NDF             number of filters in the discriminator
+  --ngf NGF             number of generator filters
+  --ndf NDF             number of discriminator filters
   --niter NITER         number of epochs to train for
   --lr LR               learning rate, default=0.0002
   --beta1 BETA1         beta1 for adam. default=0.5
-  --cuda                enables cuda
-  --mps                 enables macOS GPU
+  --dry-run             check a single training cycle works
   --ngpu NGPU           number of GPUs to use
   --netG NETG           path to netG (to continue training)
   --netD NETD           path to netD (to continue training)
   --outf OUTF           folder to output images and model checkpoints
-  --manualSeed SEED     manual seed
+  --manualSeed MANUALSEED
+                        manual seed
   --classes CLASSES     comma separated list of classes for the lsun data set
+  --accel               enables accelerator
 ```

--- a/dcgan/main.py
+++ b/dcgan/main.py
@@ -20,12 +20,11 @@ parser.add_argument('--workers', type=int, help='number of data loading workers'
 parser.add_argument('--batchSize', type=int, default=64, help='input batch size')
 parser.add_argument('--imageSize', type=int, default=64, help='the height / width of the input image to network')
 parser.add_argument('--nz', type=int, default=100, help='size of the latent z vector')
-parser.add_argument('--ngf', type=int, default=64)
-parser.add_argument('--ndf', type=int, default=64)
+parser.add_argument('--ngf', type=int, default=64, help='number of generator filters')
+parser.add_argument('--ndf', type=int, default=64, help='number of discriminator filters')
 parser.add_argument('--niter', type=int, default=25, help='number of epochs to train for')
 parser.add_argument('--lr', type=float, default=0.0002, help='learning rate, default=0.0002')
 parser.add_argument('--beta1', type=float, default=0.5, help='beta1 for adam. default=0.5')
-parser.add_argument('--cuda', action='store_true', default=False, help='enables cuda')
 parser.add_argument('--dry-run', action='store_true', help='check a single training cycle works')
 parser.add_argument('--ngpu', type=int, default=1, help='number of GPUs to use')
 parser.add_argument('--netG', default='', help="path to netG (to continue training)")
@@ -33,7 +32,7 @@ parser.add_argument('--netD', default='', help="path to netD (to continue traini
 parser.add_argument('--outf', default='.', help='folder to output images and model checkpoints')
 parser.add_argument('--manualSeed', type=int, help='manual seed')
 parser.add_argument('--classes', default='bedroom', help='comma separated list of classes for the lsun data set')
-parser.add_argument('--mps', action='store_true', default=False, help='enables macOS GPU training')
+parser.add_argument('--accel', action='store_true', default=False, help='enables accelerator')
 
 opt = parser.parse_args()
 print(opt)
@@ -51,12 +50,13 @@ torch.manual_seed(opt.manualSeed)
 
 cudnn.benchmark = True
 
-if torch.cuda.is_available() and not opt.cuda:
-    print("WARNING: You have a CUDA device, so you should probably run with --cuda")
+if opt.accel and torch.accelerator.is_available():
+    device = torch.accelerator.current_accelerator()
+else:
+    device = torch.device("cpu")
 
-if torch.backends.mps.is_available() and not opt.mps:
-    print("WARNING: You have mps device, to enable macOS GPU run with --mps")
-  
+print(f"Using device: {device}")
+
 if opt.dataroot is None and str(opt.dataset).lower() != 'fake':
     raise ValueError("`dataroot` parameter is required for dataset \"%s\"" % opt.dataset)
 
@@ -106,13 +106,6 @@ elif opt.dataset == 'fake':
 assert dataset
 dataloader = torch.utils.data.DataLoader(dataset, batch_size=opt.batchSize,
                                          shuffle=True, num_workers=int(opt.workers))
-use_mps = opt.mps and torch.backends.mps.is_available()
-if opt.cuda:
-    device = torch.device("cuda:0")
-elif use_mps:
-    device = torch.device("mps")
-else:
-    device = torch.device("cpu")
 
 ngpu = int(opt.ngpu)
 nz = int(opt.nz)
@@ -158,8 +151,11 @@ class Generator(nn.Module):
         )
 
     def forward(self, input):
+        
         if input.is_cuda and self.ngpu > 1:
             output = nn.parallel.data_parallel(self.main, input, range(self.ngpu))
+        if input.is_xpu and self.ngpu > 1:
+            output = nn.DataParallel(self.main, input, range(self.ngpu))
         else:
             output = self.main(input)
         return output
@@ -200,6 +196,8 @@ class Discriminator(nn.Module):
     def forward(self, input):
         if input.is_cuda and self.ngpu > 1:
             output = nn.parallel.data_parallel(self.main, input, range(self.ngpu))
+        if input.is_xpu and self.ngpu > 1:
+            output = nn.DataParallel(self.main, input, range(self.ngpu))
         else:
             output = self.main(input)
 

--- a/dcgan/requirements.txt
+++ b/dcgan/requirements.txt
@@ -1,3 +1,3 @@
 torch
-torchvision==0.20.0
+torchvision
 lmdb

--- a/distributed/tensor_parallelism/tensor_parallel_example.py
+++ b/distributed/tensor_parallelism/tensor_parallel_example.py
@@ -91,9 +91,6 @@ rank_log(_rank, logger, f"Device Mesh created: {device_mesh=}")
 # create model and move it to GPU - init"cuda"_mesh has already mapped GPU ids.
 tp_model = ToyModel().to("cuda")
 
-# Create an optimizer for the parallelized module.
-lr = 0.25
-optimizer = torch.optim.AdamW(tp_model.parameters(), lr=lr, foreach=True)
 
 # Custom parallelization plan for the model
 tp_model = parallelize_module(
@@ -104,6 +101,12 @@ tp_model = parallelize_module(
         "out_proj": RowwiseParallel(),
     },
 )
+
+# Create an optimizer for the parallelized module.
+lr = 0.25
+optimizer = torch.optim.AdamW(tp_model.parameters(), lr=lr, foreach=True)
+
+
 # Perform a num of iterations of forward/backward
 # and optimizations for the sharded module.
 num_iters = 10

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-sphinx
-# torch
-# PyTorch Theme
+
+sphinx==5.3.0
+#Pinned versions: 5.3.0
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinx-panels

--- a/fast_neural_style/README.md
+++ b/fast_neural_style/README.md
@@ -19,21 +19,19 @@ The program is written in Python, and uses [pytorch](http://pytorch.org/), [scip
 Stylize image
 
 ```
-python neural_style/neural_style.py eval --content-image </path/to/content/image> --model </path/to/saved/model> --output-image </path/to/output/image> --cuda 0
+python neural_style/neural_style.py eval --content-image </path/to/content/image> --model </path/to/saved/model> --output-image </path/to/output/image> --accel
 ```
 
 - `--content-image`: path to content image you want to stylize.
 - `--model`: saved model to be used for stylizing the image (eg: `mosaic.pth`)
 - `--output-image`: path for saving the output image.
 - `--content-scale`: factor for scaling down the content image if memory is an issue (eg: value of 2 will halve the height and width of content-image)
-- `--cuda 0|1`: set it to 1 for running on GPU, 0 for CPU.
-- `--mps`: use MPS device backend.
-- `--xpu`: use XPU device backend.
+- `--accel`: use accelerator
 
 Train model
 
 ```bash
-python neural_style/neural_style.py train --dataset </path/to/train-dataset> --style-image </path/to/style/image> --save-model-dir </path/to/save-model/folder> --epochs 2 --cuda 1
+python neural_style/neural_style.py train --dataset </path/to/train-dataset> --style-image </path/to/style/image> --save-model-dir </path/to/save-model/folder> --epochs 2 --accel
 ```
 
 There are several command line arguments, the important ones are listed below
@@ -41,9 +39,9 @@ There are several command line arguments, the important ones are listed below
 - `--dataset`: path to training dataset, the path should point to a folder containing another folder with all the training images. I used COCO 2014 Training images dataset [80K/13GB] [(download)](https://cocodataset.org/#download).
 - `--style-image`: path to style-image.
 - `--save-model-dir`: path to folder where trained model will be saved.
-- `--cuda 0|1`: set it to 1 for running on GPU, 0 for CPU.
-- `--mps`: use MPS device backend.
-- `--xpu`: use XPU device backend.
+- `--accel`: use accelerator.
+
+If `--accel` argument is given, pytorch will search for available hardware acceleration device and attempt to use it. This example is known to work on CUDA, MPS and XPU devices.
 
 Refer to `neural_style/neural_style.py` for other command line arguments. For training new models you might have to tune the values of `--content-weight` and `--style-weight`. The mosaic style model shown above was trained with `--content-weight 1e5` and `--style-weight 1e10`. The remaining 3 models were also trained with similar order of weight parameters with slight variation in the `--style-weight` (`5e10` or `1e11`).
 

--- a/fast_neural_style/neural_style/neural_style.py
+++ b/fast_neural_style/neural_style/neural_style.py
@@ -29,16 +29,12 @@ def check_paths(args):
 
 
 def train(args):
-    if args.cuda:
-        device = torch.device("cuda")
-    elif args.mps:
-        device = torch.device("mps")
-    elif args.xpu:
-        device = torch.device("xpu")
+    if args.accel:
+        device = torch.accelerator.current_accelerator()
     else:
         device = torch.device("cpu")
 
-    print("Device to use: ", device)
+    print(f"Using device: {device}")
 
     np.random.seed(args.seed)
     torch.manual_seed(args.seed)
@@ -129,10 +125,12 @@ def train(args):
 
 
 def stylize(args):
-    device = torch.device("cuda" if args.cuda else "cpu")
-    device = torch.device("xpu" if args.xpu else "cpu")
+    if args.accel:
+        device = torch.accelerator.current_accelerator()
+    else:
+        device = torch.device("cpu")
     
-    print("Device to use: ", device)
+    print(f"Using device: {device}")
 
     content_image = utils.load_image(args.content_image, scale=args.content_scale)
     content_transform = transforms.Compose([
@@ -212,8 +210,8 @@ def main():
                                   help="size of training images, default is 256 X 256")
     train_arg_parser.add_argument("--style-size", type=int, default=None,
                                   help="size of style-image, default is the original size of style image")
-    train_arg_parser.add_argument("--cuda", type=int, required=True,
-                                  help="set it to 1 for running on GPU, 0 for CPU")
+    train_arg_parser.add_argument('--accel', action='store_true',
+                                  help='use accelerator')
     train_arg_parser.add_argument("--seed", type=int, default=42,
                                   help="random seed for training")
     train_arg_parser.add_argument("--content-weight", type=float, default=1e5,
@@ -226,10 +224,6 @@ def main():
                                   help="number of images after which the training loss is logged, default is 500")
     train_arg_parser.add_argument("--checkpoint-interval", type=int, default=2000,
                                   help="number of batches after which a checkpoint of the trained model will be created")
-    train_arg_parser.add_argument('--mps', action='store_true',
-                                  help='enable macOS GPU training')
-    train_arg_parser.add_argument('--xpu', action='store_true',
-                                  help='enable Intel XPU training')
 
     eval_arg_parser = subparsers.add_parser("eval", help="parser for evaluation/stylizing arguments")
     eval_arg_parser.add_argument("--content-image", type=str, required=True,
@@ -240,28 +234,21 @@ def main():
                                  help="path for saving the output image")
     eval_arg_parser.add_argument("--model", type=str, required=True,
                                  help="saved model to be used for stylizing the image. If file ends in .pth - PyTorch path is used, if in .onnx - Caffe2 path")
-    eval_arg_parser.add_argument("--cuda", type=int, default=False,
-                                 help="set it to 1 for running on cuda, 0 for CPU")
     eval_arg_parser.add_argument("--export_onnx", type=str,
                                  help="export ONNX model to a given file")
-    eval_arg_parser.add_argument('--mps', action='store_true',
-                                 help='enable macOS GPU evaluation')
-    eval_arg_parser.add_argument('--xpu', action='store_true',
-                                 help='enable Intel XPU evaluation')
-
+    eval_arg_parser.add_argument('--accel', action='store_true',
+                                 help='use accelerator')
 
     args = main_arg_parser.parse_args()
 
     if args.subcommand is None:
         print("ERROR: specify either train or eval")
         sys.exit(1)
-    if args.cuda and not torch.cuda.is_available():
-        print("ERROR: cuda is not available, try running on CPU")
+    if args.accel and not torch.accelerator.is_available():
+        print("ERROR: accelerator is not available, try running on CPU")
         sys.exit(1)
-    if not args.mps and torch.backends.mps.is_available():
-        print("WARNING: mps is available, run with --mps to enable macOS GPU")
-    if not args.xpu and torch.xpu.is_available():
-        print("WARNING: XPU is available, run with --xpu to enable Intel XPU")
+    if not args.accel and torch.accelerator.is_available():
+        print("WARNING: accelerator is available, run with --accel to enable it")
 
     if args.subcommand == "train":
         check_paths(args)

--- a/fast_neural_style/requirements.txt
+++ b/fast_neural_style/requirements.txt
@@ -1,3 +1,3 @@
 numpy
-torch
+torch>=2.6
 torchvision

--- a/gat/README.md
+++ b/gat/README.md
@@ -87,8 +87,7 @@ options:
   --concat-heads        wether to concatinate attention heads, or average over them (default: False)
   --val-every VAL_EVERY
                         epochs to wait for print training and validation evaluation (default: 20)
-  --no-cuda             disables CUDA training
-  --no-mps              disables macOS GPU training
+  --no-accel            disables accelerator
   --dry-run             quickly check a single pass
   --seed S              random seed (default: 13)
 ```

--- a/gat/main.py
+++ b/gat/main.py
@@ -303,29 +303,25 @@ if __name__ == '__main__':
                         help='dimension of the hidden representation (default: 64)')
     parser.add_argument('--num-heads', type=int, default=8,
                         help='number of the attention heads (default: 4)')
-    parser.add_argument('--concat-heads', action='store_true', default=False,
+    parser.add_argument('--concat-heads', action='store_true',
                         help='wether to concatinate attention heads, or average over them (default: False)')
     parser.add_argument('--val-every', type=int, default=20,
                         help='epochs to wait for print training and validation evaluation (default: 20)')
-    parser.add_argument('--no-cuda', action='store_true', default=False,
+    parser.add_argument('--no-accel', action='store_true',
                         help='disables CUDA training')
-    parser.add_argument('--no-mps', action='store_true', default=False,
-                        help='disables macOS GPU training')
-    parser.add_argument('--dry-run', action='store_true', default=False,
+    parser.add_argument('--dry-run', action='store_true', 
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=13, metavar='S',
                         help='random seed (default: 13)')
     args = parser.parse_args()
 
     torch.manual_seed(args.seed)
-    use_cuda = not args.no_cuda and torch.cuda.is_available()
-    use_mps = not args.no_mps and torch.backends.mps.is_available()
+
+    use_accel = not args.no_accel and torch.accelerator.is_available()
 
     # Set the device to run on
-    if use_cuda:
-        device = torch.device('cuda')
-    elif use_mps:
-        device = torch.device('mps')
+    if use_accel:
+        device = torch.accelerator.current_accelerator()
     else:
         device = torch.device('cpu')
     print(f'Using {device} device')

--- a/gat/requirements.txt
+++ b/gat/requirements.txt
@@ -1,3 +1,3 @@
 torch
 requests
-numpy<2
+numpy

--- a/mnist/main.py
+++ b/mnist/main.py
@@ -82,39 +82,35 @@ def main():
                         help='learning rate (default: 1.0)')
     parser.add_argument('--gamma', type=float, default=0.7, metavar='M',
                         help='Learning rate step gamma (default: 0.7)')
-    parser.add_argument('--no-cuda', action='store_true', default=False,
-                        help='disables CUDA training')
-    parser.add_argument('--no-mps', action='store_true', default=False,
-                        help='disables macOS GPU training')
-    parser.add_argument('--dry-run', action='store_true', default=False,
+    parser.add_argument('--no-accel', action='store_true',
+                        help='disables accelerator')
+    parser.add_argument('--dry-run', action='store_true',
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=1, metavar='S',
                         help='random seed (default: 1)')
     parser.add_argument('--log-interval', type=int, default=10, metavar='N',
                         help='how many batches to wait before logging training status')
-    parser.add_argument('--save-model', action='store_true', default=False,
+    parser.add_argument('--save-model', action='store_true', 
                         help='For Saving the current Model')
     args = parser.parse_args()
-    use_cuda = not args.no_cuda and torch.cuda.is_available()
-    use_mps = not args.no_mps and torch.backends.mps.is_available()
+
+    use_accel = not args.no_accel and torch.accelerator.is_available()
 
     torch.manual_seed(args.seed)
 
-    if use_cuda:
-        device = torch.device("cuda")
-    elif use_mps:
-        device = torch.device("mps")
+    if use_accel:
+        device = torch.accelerator.current_accelerator()
     else:
         device = torch.device("cpu")
 
     train_kwargs = {'batch_size': args.batch_size}
     test_kwargs = {'batch_size': args.test_batch_size}
-    if use_cuda:
-        cuda_kwargs = {'num_workers': 1,
+    if use_accel:
+        accel_kwargs = {'num_workers': 1,
                        'pin_memory': True,
                        'shuffle': True}
-        train_kwargs.update(cuda_kwargs)
-        test_kwargs.update(cuda_kwargs)
+        train_kwargs.update(accel_kwargs)
+        test_kwargs.update(accel_kwargs)
 
     transform=transforms.Compose([
         transforms.ToTensor(),

--- a/mnist/requirements.txt
+++ b/mnist/requirements.txt
@@ -1,2 +1,2 @@
 torch
-torchvision==0.20.0
+torchvision

--- a/mnist_forward_forward/README.md
+++ b/mnist_forward_forward/README.md
@@ -16,8 +16,7 @@ optional arguments:
   -h, --help            show this help message and exit
   --epochs EPOCHS       number of epochs to train (default: 1000)
   --lr LR               learning rate (default: 0.03)
-  --no_cuda             disables CUDA training
-  --no_mps              disables MPS training
+  --no_accel            disables accelerator
   --seed SEED           random seed (default: 1)
   --save_model          For saving the current Model
   --train_size TRAIN_SIZE

--- a/mnist_forward_forward/main.py
+++ b/mnist_forward_forward/main.py
@@ -102,10 +102,7 @@ if __name__ == "__main__":
         help="learning rate (default: 0.03)",
     )
     parser.add_argument(
-        "--no_cuda", action="store_true", default=False, help="disables CUDA training"
-    )
-    parser.add_argument(
-        "--no_mps", action="store_true", default=False, help="disables MPS training"
+        "--no_accel", action="store_true", help="disables accelerator"
     )
     parser.add_argument(
         "--seed", type=int, default=1, metavar="S", help="random seed (default: 1)"
@@ -113,7 +110,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "--save_model",
         action="store_true",
-        default=False,
         help="For saving the current Model",
     )
     parser.add_argument(
@@ -126,7 +122,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "--save-model",
         action="store_true",
-        default=False,
         help="For Saving the current Model",
     )
     parser.add_argument(
@@ -137,22 +132,19 @@ if __name__ == "__main__":
         help="how many batches to wait before logging training status",
     )
     args = parser.parse_args()
-    use_cuda = not args.no_cuda and torch.cuda.is_available()
-    use_mps = not args.no_mps and torch.backends.mps.is_available()
-    if use_cuda:
-        device = torch.device("cuda")
-    elif use_mps:
-        device = torch.device("mps")
+    use_accel = not args.no_accel and torch.accelerator.is_available()
+    if use_accel:
+        device = torch.accelerator.current_accelerator()
     else:
         device = torch.device("cpu")
 
     train_kwargs = {"batch_size": args.train_size}
     test_kwargs = {"batch_size": args.test_size}
 
-    if use_cuda:
-        cuda_kwargs = {"num_workers": 1, "pin_memory": True, "shuffle": True}
-        train_kwargs.update(cuda_kwargs)
-        test_kwargs.update(cuda_kwargs)
+    if use_accel:
+        accel_kwargs = {"num_workers": 1, "pin_memory": True, "shuffle": True}
+        train_kwargs.update(accel_kwargs)
+        test_kwargs.update(accel_kwargs)
 
     transform = Compose(
         [

--- a/mnist_forward_forward/requirements.txt
+++ b/mnist_forward_forward/requirements.txt
@@ -1,2 +1,2 @@
 torch
-torchvision==0.20.0
+torchvision

--- a/mnist_rnn/README.md
+++ b/mnist_rnn/README.md
@@ -8,3 +8,18 @@ pip install -r requirements.txt
 python main.py
 # CUDA_VISIBLE_DEVICES=2 python main.py  # to specify GPU id to ex. 2
 ```
+
+```bash
+optional arguments:
+  -h, --help            show this help message and exit
+  --batch_size          input batch_size for training (default:64)
+  --testing_batch_size  input batch size for testing (default: 1000)
+  --epochs EPOCHS       number of epochs to train (default: 14)
+  --lr LR               learning rate (default: 0.1)
+  --gamma               learning rate step gamma (default: 0.7)
+  --accel               enables accelerator
+  --seed SEED           random seed (default: 1)
+  --save_model          For saving the current Model
+  --log_interval        how many batches to wait before logging training status
+  --dry-run             quickly check a single pass
+```

--- a/mnist_rnn/main.py
+++ b/mnist_rnn/main.py
@@ -91,32 +91,26 @@ def main():
                         help='learning rate (default: 0.1)')
     parser.add_argument('--gamma', type=float, default=0.7, metavar='M',
                         help='learning rate step gamma (default: 0.7)')
-    parser.add_argument('--cuda', action='store_true', default=False,
-                        help='enables CUDA training')
-    parser.add_argument('--mps', action="store_true", default=False,
-                        help="enables MPS training")
-    parser.add_argument('--dry-run', action='store_true', default=False,
+    parser.add_argument('--accel', action='store_true',
+                        help='enables accelerator')
+    parser.add_argument('--dry-run', action='store_true',
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=1, metavar='S',
                         help='random seed (default: 1)')
     parser.add_argument('--log-interval', type=int, default=10, metavar='N',
                         help='how many batches to wait before logging training status')
-    parser.add_argument('--save-model', action='store_true', default=False,
+    parser.add_argument('--save-model', action='store_true',
                         help='for Saving the current Model')
     args = parser.parse_args()
 
-    if args.cuda and not args.mps:
-        device = "cuda"
-    elif args.mps and not args.cuda:
-        device = "mps"
+    if args.accel:
+        device = torch.accelerator.current_accelerator()
     else:
-        device = "cpu"
-
-    device = torch.device(device)
+        device = torch.device("cpu")
 
     torch.manual_seed(args.seed)
 
-    kwargs = {'num_workers': 1, 'pin_memory': True} if args.cuda else {}
+    kwargs = {'num_workers': 1, 'pin_memory': True} if args.accel else {}
     train_loader = torch.utils.data.DataLoader(
         datasets.MNIST('../data', train=True, download=True,
                        transform=transforms.Compose([

--- a/mnist_rnn/requirements.txt
+++ b/mnist_rnn/requirements.txt
@@ -1,2 +1,2 @@
 torch
-torchvision==0.20.0
+torchvision

--- a/run_python_examples.sh
+++ b/run_python_examples.sh
@@ -93,7 +93,7 @@ function mnist() {
   uv run main.py --epochs 1 --dry-run || error "mnist example failed"
 }
 function mnist_forward_forward() {
-  uv run main.py --epochs 1 --no_mps --no_cuda || error "mnist forward forward failed"
+  uv run main.py --epochs 1 --no_accel || error "mnist forward forward failed"
 
 }
 function mnist_hogwild() {

--- a/run_python_examples.sh
+++ b/run_python_examples.sh
@@ -13,6 +13,12 @@
 # To test examples on CUDA accelerator, run as:
 #   USE_CUDA=True ./run_python_examples.sh
 #
+# To test examples on hardware accelerator (CUDA, MPS, XPU, etc.), run as:
+#   USE_ACCEL=True ./run_python_examples.sh
+# NOTE: USE_ACCEL relies on torch.accelerator API and not all examples are converted
+# to use it at the moment. Thus, expect failures using this flag on non-CUDA accelerators
+# and consider to run examples one by one.
+#
 # Script requires uv to be installed. When executed, script will install prerequisites from
 # `requirements.txt` for each example. If ran within activated virtual environment (uv venv,
 # python -m venv, conda) this might reinstall some of the packages. To change pip installation
@@ -27,17 +33,24 @@
 BASE_DIR="$(pwd)/$(dirname $0)"
 source $BASE_DIR/utils.sh
 
+# TODO: Leave only USE_ACCEL and drop USE_CUDA once all examples will be converted
+# to torch.accelerator API. For now, just add USE_ACCEL as an alias for USE_CUDA.
+if [ -n "$USE_ACCEL" ]; then
+  USE_CUDA=$USE_ACCEL
+fi
 USE_CUDA=${USE_CUDA:-False}
 case $USE_CUDA in
   "True")
     echo "using cuda"
     CUDA=1
     CUDA_FLAG="--cuda"
+    ACCEL_FLAG="--accel"
     ;;
   "False")
     echo "not using cuda"
     CUDA=0
     CUDA_FLAG=""
+    ACCEL_FLAG=""
     ;;
   "")
     exit 1;
@@ -56,7 +69,7 @@ function fast_neural_style() {
   test -d "saved_models" || { error "saved models not found"; return; }
 
   echo "running fast neural style model"
-  uv run neural_style/neural_style.py eval --content-image images/content-images/amber.jpg --model saved_models/candy.pth --output-image images/output-images/amber-candy.jpg --cuda $CUDA --mps || error "neural_style.py failed"
+  uv run neural_style/neural_style.py eval --content-image images/content-images/amber.jpg --model saved_models/candy.pth --output-image images/output-images/amber-candy.jpg $ACCEL_FLAG || error "neural_style.py failed"
 }
 
 function imagenet() {

--- a/run_python_examples.sh
+++ b/run_python_examples.sh
@@ -58,7 +58,7 @@ case $USE_CUDA in
 esac
 
 function dcgan() {
-  uv run main.py --dataset fake $CUDA_FLAG --mps --dry-run || error "dcgan failed"
+  uv run main.py --dataset fake --accel --dry-run || error "dcgan failed"
 }
 
 function fast_neural_style() {

--- a/siamese_network/README.md
+++ b/siamese_network/README.md
@@ -1,7 +1,37 @@
 # Siamese Network Example
+Siamese network for image similarity estimation.
+The network is composed of two identical networks, one for each input.
+The output of each network is concatenated and passed to a linear layer.
+The output of the linear layer passed through a sigmoid function.
+[FaceNet](https://arxiv.org/pdf/1503.03832.pdf) is a variant of the Siamese network.
+This implementation varies from FaceNet as we use the `ResNet-18` model from
+[Deep Residual Learning for Image Recognition](https://arxiv.org/pdf/1512.03385.pdf) as our feature extractor.
+In addition, we aren't using `TripletLoss` as the MNIST dataset is simple, so `BCELoss` can do the trick.
 
 ```bash
 pip install -r requirements.txt
 python main.py
 # CUDA_VISIBLE_DEVICES=2 python main.py  # to specify GPU id to ex. 2
 ```
+Optionally, you can add the following arguments to customize your execution.
+
+```bash
+--batch-size            input batch size for training (default: 64)
+--test-batch-size       input batch size for testing (default: 1000)
+--epochs                number of epochs to train (default: 14)
+--lr                    learning rate (default: 1.0)
+--gamma                 learning rate step gamma (default: 0.7)
+--accel                 use accelerator
+--dry-run               quickly check a single pass
+--seed                  random seed (default: 1)
+--log-interval          how many batches to wait before logging training status
+--save-model            Saving the current Model
+```
+
+To execute in an GPU, add the --accel argument to the command. For example:
+
+```bash
+python main.py --accel
+```
+
+This command will execute the example on the detected GPU.

--- a/siamese_network/requirements.txt
+++ b/siamese_network/requirements.txt
@@ -1,2 +1,2 @@
 torch
-torchvision==0.20.0
+torchvision

--- a/vae/README.md
+++ b/vae/README.md
@@ -8,14 +8,12 @@ pip install -r requirements.txt
 python main.py
 ```
 
-The main.py script accepts the following arguments:
+The main.py script accepts the following optional arguments:
 
 ```bash
-optional arguments:
-  --batch-size		input batch size for training (default: 128)
-  --epochs		number of epochs to train (default: 10)
-  --no-cuda		enables CUDA training
-  --mps         enables GPU on macOS
-  --seed		random seed (default: 1)
-  --log-interval	how many batches to wait before logging training status
+--batch-size            input batch size for training (default: 128)
+--epochs                number of epochs to train (default: 10)
+--accel                 use accelerator
+--seed                  random seed (default: 1)
+--log-interval	        how many batches to wait before logging training status
 ```

--- a/vae/requirements.txt
+++ b/vae/requirements.txt
@@ -1,4 +1,4 @@
 torch
-torchvision==0.20.0
+torchvision
 tqdm
 six


### PR DESCRIPTION
- Updated dcgan/main.py flags to use torch.accelerator
- updated dcgan/README.md to match dcgan/main.py changes
- Updated run_python_tests.sh to set dcgan --accel flag

note: additional files changes might be due to the latest versions from the fork. 