### PR TITLE
Use torch.accelerator API in Imagenet example

### DIFF
--- a/fast_neural_style/README.md
+++ b/fast_neural_style/README.md
@@ -26,8 +26,9 @@ python neural_style/neural_style.py eval --content-image </path/to/content/image
 - `--model`: saved model to be used for stylizing the image (eg: `mosaic.pth`)
 - `--output-image`: path for saving the output image.
 - `--content-scale`: factor for scaling down the content image if memory is an issue (eg: value of 2 will halve the height and width of content-image)
-- `--cuda`: set it to 1 for running on GPU, 0 for CPU.
-- `--mps`: set it to 1 for running on macOS GPU
+- `--cuda 0|1`: set it to 1 for running on GPU, 0 for CPU.
+- `--mps`: use MPS device backend.
+- `--xpu`: use XPU device backend.
 
 Train model
 
@@ -40,8 +41,9 @@ There are several command line arguments, the important ones are listed below
 - `--dataset`: path to training dataset, the path should point to a folder containing another folder with all the training images. I used COCO 2014 Training images dataset [80K/13GB] [(download)](https://cocodataset.org/#download).
 - `--style-image`: path to style-image.
 - `--save-model-dir`: path to folder where trained model will be saved.
-- `--cuda`: set it to 1 for running on GPU, 0 for CPU.
-- `--mps`: set it to 1 for running on macOS GPU
+- `--cuda 0|1`: set it to 1 for running on GPU, 0 for CPU.
+- `--mps`: use MPS device backend.
+- `--xpu`: use XPU device backend.
 
 Refer to `neural_style/neural_style.py` for other command line arguments. For training new models you might have to tune the values of `--content-weight` and `--style-weight`. The mosaic style model shown above was trained with `--content-weight 1e5` and `--style-weight 1e10`. The remaining 3 models were also trained with similar order of weight parameters with slight variation in the `--style-weight` (`5e10` or `1e11`).
 

--- a/fast_neural_style/neural_style/neural_style.py
+++ b/fast_neural_style/neural_style/neural_style.py
@@ -33,8 +33,12 @@ def train(args):
         device = torch.device("cuda")
     elif args.mps:
         device = torch.device("mps")
+    elif args.xpu:
+        device = torch.device("xpu")
     else:
         device = torch.device("cpu")
+
+    print("Device to use: ", device)
 
     np.random.seed(args.seed)
     torch.manual_seed(args.seed)
@@ -126,6 +130,9 @@ def train(args):
 
 def stylize(args):
     device = torch.device("cuda" if args.cuda else "cpu")
+    device = torch.device("xpu" if args.xpu else "cpu")
+    
+    print("Device to use: ", device)
 
     content_image = utils.load_image(args.content_image, scale=args.content_scale)
     content_transform = transforms.Compose([
@@ -219,6 +226,10 @@ def main():
                                   help="number of images after which the training loss is logged, default is 500")
     train_arg_parser.add_argument("--checkpoint-interval", type=int, default=2000,
                                   help="number of batches after which a checkpoint of the trained model will be created")
+    train_arg_parser.add_argument('--mps', action='store_true',
+                                  help='enable macOS GPU training')
+    train_arg_parser.add_argument('--xpu', action='store_true',
+                                  help='enable Intel XPU training')
 
     eval_arg_parser = subparsers.add_parser("eval", help="parser for evaluation/stylizing arguments")
     eval_arg_parser.add_argument("--content-image", type=str, required=True,
@@ -233,7 +244,11 @@ def main():
                                  help="set it to 1 for running on cuda, 0 for CPU")
     eval_arg_parser.add_argument("--export_onnx", type=str,
                                  help="export ONNX model to a given file")
-    eval_arg_parser.add_argument('--mps', action='store_true', default=False, help='enable macOS GPU training')
+    eval_arg_parser.add_argument('--mps', action='store_true',
+                                 help='enable macOS GPU evaluation')
+    eval_arg_parser.add_argument('--xpu', action='store_true',
+                                 help='enable Intel XPU evaluation')
+
 
     args = main_arg_parser.parse_args()
 
@@ -245,6 +260,8 @@ def main():
         sys.exit(1)
     if not args.mps and torch.backends.mps.is_available():
         print("WARNING: mps is available, run with --mps to enable macOS GPU")
+    if not args.xpu and torch.xpu.is_available():
+        print("WARNING: XPU is available, run with --xpu to enable Intel XPU")
 
     if args.subcommand == "train":
         check_paths(args)

--- a/gat/README.md
+++ b/gat/README.md
@@ -89,6 +89,7 @@ options:
                         epochs to wait for print training and validation evaluation (default: 20)
   --no-cuda             disables CUDA training
   --no-mps              disables macOS GPU training
+  --no-xpu              disables XPU training
   --dry-run             quickly check a single pass
   --seed S              random seed (default: 13)
 ```

--- a/gat/main.py
+++ b/gat/main.py
@@ -303,15 +303,17 @@ if __name__ == '__main__':
                         help='dimension of the hidden representation (default: 64)')
     parser.add_argument('--num-heads', type=int, default=8,
                         help='number of the attention heads (default: 4)')
-    parser.add_argument('--concat-heads', action='store_true', default=False,
+    parser.add_argument('--concat-heads', action='store_true',
                         help='wether to concatinate attention heads, or average over them (default: False)')
     parser.add_argument('--val-every', type=int, default=20,
                         help='epochs to wait for print training and validation evaluation (default: 20)')
-    parser.add_argument('--no-cuda', action='store_true', default=False,
+    parser.add_argument('--no-cuda', action='store_true',
                         help='disables CUDA training')
-    parser.add_argument('--no-mps', action='store_true', default=False,
+    parser.add_argument('--no-xpu', action='store_true',
+                        help='disables XPU training')
+    parser.add_argument('--no-mps', action='store_true',
                         help='disables macOS GPU training')
-    parser.add_argument('--dry-run', action='store_true', default=False,
+    parser.add_argument('--dry-run', action='store_true',
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=13, metavar='S',
                         help='random seed (default: 13)')
@@ -320,12 +322,15 @@ if __name__ == '__main__':
     torch.manual_seed(args.seed)
     use_cuda = not args.no_cuda and torch.cuda.is_available()
     use_mps = not args.no_mps and torch.backends.mps.is_available()
+    use_xpu = not args.no_xpu and torch.xpu.is_available()
 
     # Set the device to run on
     if use_cuda:
         device = torch.device('cuda')
     elif use_mps:
         device = torch.device('mps')
+    elif use_xpu:
+        device = torch.device('xpu')
     else:
         device = torch.device('cpu')
     print(f'Using {device} device')

--- a/imagenet/README.md
+++ b/imagenet/README.md
@@ -33,7 +33,9 @@ python main.py -a resnet18 --dummy
 
 ## Multi-processing Distributed Data Parallel Training
 
-You should always use the NCCL backend for multi-processing distributed training since it currently provides the best distributed training performance.
+If running on CUDA, you should always use the NCCL backend for multi-processing distributed training since it currently provides the best distributed training performance.
+
+For XPU multiprocessing is not supported as of PyTorch 2.6.
 
 ### Single node, multiple GPUs:
 
@@ -59,7 +61,7 @@ python main.py -a resnet50 --dist-url 'tcp://IP_OF_NODE0:FREEPORT' --dist-backen
 
 ```bash
 usage: main.py [-h] [-a ARCH] [-j N] [--epochs N] [--start-epoch N] [-b N] [--lr LR] [--momentum M] [--wd W] [-p N] [--resume PATH] [-e] [--pretrained] [--world-size WORLD_SIZE] [--rank RANK]
-               [--dist-url DIST_URL] [--dist-backend DIST_BACKEND] [--seed SEED] [--gpu GPU] [--multiprocessing-distributed] [--dummy]
+               [--dist-url DIST_URL] [--dist-backend DIST_BACKEND] [--seed SEED] [--gpu GPU] [--no-accel][--multiprocessing-distributed] [--dummy]
                [DIR]
 
 PyTorch ImageNet Training
@@ -96,6 +98,7 @@ optional arguments:
                         distributed backend
   --seed SEED           seed for initializing training.
   --gpu GPU             GPU id to use.
+  --no-accel            disables accelerator
   --multiprocessing-distributed
                         Use multi-processing distributed training to launch N processes per node, which has N GPUs. This is the fastest way to use PyTorch for either single node or multi node data parallel
                         training

--- a/imagenet/requirements.txt
+++ b/imagenet/requirements.txt
@@ -1,2 +1,2 @@
-torch
-torchvision==0.20.0
+torch>=2.6
+torchvision

--- a/mnist/main.py
+++ b/mnist/main.py
@@ -82,21 +82,24 @@ def main():
                         help='learning rate (default: 1.0)')
     parser.add_argument('--gamma', type=float, default=0.7, metavar='M',
                         help='Learning rate step gamma (default: 0.7)')
-    parser.add_argument('--no-cuda', action='store_true', default=False,
+    parser.add_argument('--no-cuda', action='store_true',
                         help='disables CUDA training')
-    parser.add_argument('--no-mps', action='store_true', default=False,
+    parser.add_argument('--no-mps', action='store_true',
                         help='disables macOS GPU training')
-    parser.add_argument('--dry-run', action='store_true', default=False,
+    parser.add_argument('--no-xpu', action='store_true',
+                        help='disables Intel GPU training')
+    parser.add_argument('--dry-run', action='store_true',
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=1, metavar='S',
                         help='random seed (default: 1)')
     parser.add_argument('--log-interval', type=int, default=10, metavar='N',
                         help='how many batches to wait before logging training status')
-    parser.add_argument('--save-model', action='store_true', default=False,
+    parser.add_argument('--save-model', action='store_true',
                         help='For Saving the current Model')
     args = parser.parse_args()
     use_cuda = not args.no_cuda and torch.cuda.is_available()
     use_mps = not args.no_mps and torch.backends.mps.is_available()
+    use_xpu = not args.no_mps and torch.xpu.is_available()
 
     torch.manual_seed(args.seed)
 
@@ -104,6 +107,8 @@ def main():
         device = torch.device("cuda")
     elif use_mps:
         device = torch.device("mps")
+    elif use_xpu:
+        device = torch.device("xpu")
     else:
         device = torch.device("cpu")
 

--- a/mnist_forward_forward/README.md
+++ b/mnist_forward_forward/README.md
@@ -18,6 +18,7 @@ optional arguments:
   --lr LR               learning rate (default: 0.03)
   --no_cuda             disables CUDA training
   --no_mps              disables MPS training
+  --no_xpu              disables XPU training
   --seed SEED           random seed (default: 1)
   --save_model          For saving the current Model
   --train_size TRAIN_SIZE

--- a/mnist_forward_forward/main.py
+++ b/mnist_forward_forward/main.py
@@ -102,10 +102,13 @@ if __name__ == "__main__":
         help="learning rate (default: 0.03)",
     )
     parser.add_argument(
-        "--no_cuda", action="store_true", default=False, help="disables CUDA training"
+        "--no_cuda", action="store_true", help="disables CUDA training"
     )
     parser.add_argument(
-        "--no_mps", action="store_true", default=False, help="disables MPS training"
+        "--no_mps", action="store_true", help="disables MPS training"
+    )
+    parser.add_argument(
+        "--no_xpu", action="store_true", help="disables XPU training"
     )
     parser.add_argument(
         "--seed", type=int, default=1, metavar="S", help="random seed (default: 1)"
@@ -113,7 +116,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "--save_model",
         action="store_true",
-        default=False,
         help="For saving the current Model",
     )
     parser.add_argument(
@@ -126,7 +128,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "--save-model",
         action="store_true",
-        default=False,
         help="For Saving the current Model",
     )
     parser.add_argument(
@@ -139,10 +140,13 @@ if __name__ == "__main__":
     args = parser.parse_args()
     use_cuda = not args.no_cuda and torch.cuda.is_available()
     use_mps = not args.no_mps and torch.backends.mps.is_available()
+    use_xpu = not args.no_xpu and torch.xpu.is_available()
     if use_cuda:
         device = torch.device("cuda")
     elif use_mps:
         device = torch.device("mps")
+    elif use_xpu:
+        device = torch.device("xpu")
     else:
         device = torch.device("cpu")
 

--- a/mnist_rnn/README.md
+++ b/mnist_rnn/README.md
@@ -8,3 +8,20 @@ pip install -r requirements.txt
 python main.py
 # CUDA_VISIBLE_DEVICES=2 python main.py  # to specify GPU id to ex. 2
 ```
+
+```bash
+optional arguments:
+  -h, --help            show this help message and exit
+  --batch_size          input batch_size for training (default:64)
+  --testing_batch_size  input batch size for testing (default: 1000)
+  --epochs EPOCHS       number of epochs to train (default: 14)
+  --lr LR               learning rate (default: 0.1)
+  --gamma               learning rate step gamma (default: 0.7)
+  --cuda                enables CUDA training
+  --xpu                 enables XPU training
+  --mps                 enables macos GPU training
+  --seed SEED           random seed (default: 1)
+  --save_model          For saving the current Model
+  --log_interval        how many batches to wait before logging training status
+  --dry-run             quickly check a single pass
+```

--- a/mnist_rnn/main.py
+++ b/mnist_rnn/main.py
@@ -93,15 +93,17 @@ def main():
                         help='learning rate step gamma (default: 0.7)')
     parser.add_argument('--cuda', action='store_true', default=False,
                         help='enables CUDA training')
-    parser.add_argument('--mps', action="store_true", default=False,
+    parser.add_argument('--mps', action="store_true", 
                         help="enables MPS training")
-    parser.add_argument('--dry-run', action='store_true', default=False,
+    parser.add_argument('--xpu', action='store_true',
+                        help='enables XPU training')
+    parser.add_argument('--dry-run', action='store_true',
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=1, metavar='S',
                         help='random seed (default: 1)')
     parser.add_argument('--log-interval', type=int, default=10, metavar='N',
                         help='how many batches to wait before logging training status')
-    parser.add_argument('--save-model', action='store_true', default=False,
+    parser.add_argument('--save-model', action='store_true',
                         help='for Saving the current Model')
     args = parser.parse_args()
 
@@ -109,6 +111,8 @@ def main():
         device = "cuda"
     elif args.mps and not args.cuda:
         device = "mps"
+    elif args.xpu:
+        device = "xpu"
     else:
         device = "cpu"
 

--- a/siamese_network/README.md
+++ b/siamese_network/README.md
@@ -1,7 +1,42 @@
 # Siamese Network Example
 
+Siamese network for image similarity estimation.
+The network is composed of two identical networks, one for each input.
+The output of each network is concatenated and passed to a linear layer.
+The output of the linear layer passed through a sigmoid function.
+[FaceNet](https://arxiv.org/pdf/1503.03832.pdf) is a variant of the Siamese network.
+This implementation varies from FaceNet as we use the `ResNet-18` model from
+[Deep Residual Learning for Image Recognition](https://arxiv.org/pdf/1512.03385.pdf) as our feature extractor.
+In addition, we aren't using `TripletLoss` as the MNIST dataset is simple, so `BCELoss` can do the trick.
+
 ```bash
 pip install -r requirements.txt
 python main.py
-# CUDA_VISIBLE_DEVICES=2 python main.py  # to specify GPU id to ex. 2
 ```
+
+Optionally, you can add the following arguments to customize your execution.
+
+```bash
+--batch-size            input batch size for training (default: 64)
+--test-batch-size       input batch size for testing (default: 1000)
+--epochs                number of epochs to train (default: 14)
+--lr                    learning rate (default: 1.0)
+--gamma                 learning rate step gamma (default: 0.7)
+--no-cuda               disables CUDA training
+--no-xpu                disables XPU training
+--no-mps                disables macOS GPU training
+--dry-run               quickly check a single pass
+--seed                  random seed (default: 1)
+--log-interval          how many batches to wait before logging training status
+--save-model            Saving the current Model
+```
+
+If a GPU device (CUDA, XPU, or MPS) is detected, the example will be executed on the GPU by default; otherwise, it will run on the CPU.
+
+To disable the GPU option, add the appropriate argument to the command. For example:
+
+```bash
+python main.py --no-xpu
+```
+
+This command will execute the example on the CPU even if your system successfully detects an XPU.

--- a/siamese_network/main.py
+++ b/siamese_network/main.py
@@ -247,31 +247,38 @@ def main():
                         help='learning rate (default: 1.0)')
     parser.add_argument('--gamma', type=float, default=0.7, metavar='M',
                         help='Learning rate step gamma (default: 0.7)')
-    parser.add_argument('--no-cuda', action='store_true', default=False,
+    parser.add_argument('--no-cuda', action='store_true',
                         help='disables CUDA training')
-    parser.add_argument('--no-mps', action='store_true', default=False,
+    parser.add_argument('--no-xpu', action='store_true',
+                        help='disables XPU training')
+    parser.add_argument('--no-mps', action='store_true',
                         help='disables macOS GPU training')
-    parser.add_argument('--dry-run', action='store_true', default=False,
+    parser.add_argument('--dry-run', action='store_true',
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=1, metavar='S',
                         help='random seed (default: 1)')
     parser.add_argument('--log-interval', type=int, default=10, metavar='N',
                         help='how many batches to wait before logging training status')
-    parser.add_argument('--save-model', action='store_true', default=False,
+    parser.add_argument('--save-model', action='store_true',
                         help='For Saving the current Model')
     args = parser.parse_args()
     
     use_cuda = not args.no_cuda and torch.cuda.is_available()
+    use_xpu = not args.no_xpu and torch.xpu.is_available()
     use_mps = not args.no_mps and torch.backends.mps.is_available()
 
     torch.manual_seed(args.seed)
 
     if use_cuda:
         device = torch.device("cuda")
+    elif use_xpu:
+        device = torch.device("xpu")
     elif use_mps:
         device = torch.device("mps")
     else:
         device = torch.device("cpu")
+
+    print('Device to use: ', device)
 
     train_kwargs = {'batch_size': args.batch_size}
     test_kwargs = {'batch_size': args.test_batch_size}

--- a/vae/README.md
+++ b/vae/README.md
@@ -14,8 +14,9 @@ The main.py script accepts the following arguments:
 optional arguments:
   --batch-size		input batch size for training (default: 128)
   --epochs		number of epochs to train (default: 10)
-  --no-cuda		enables CUDA training
-  --mps         enables GPU on macOS
+  --no-cuda		disables CUDA training
+  --no-mps	        disables GPU on macOS
+  --no-xpu		disables XPU training in Intel GPUs
   --seed		random seed (default: 1)
   --log-interval	how many batches to wait before logging training status
 ```

--- a/vae/main.py
+++ b/vae/main.py
@@ -13,10 +13,12 @@ parser.add_argument('--batch-size', type=int, default=128, metavar='N',
                     help='input batch size for training (default: 128)')
 parser.add_argument('--epochs', type=int, default=10, metavar='N',
                     help='number of epochs to train (default: 10)')
-parser.add_argument('--no-cuda', action='store_true', default=False,
+parser.add_argument('--no-cuda', action='store_true',
                     help='disables CUDA training')
-parser.add_argument('--no-mps', action='store_true', default=False,
+parser.add_argument('--no-mps', action='store_true',
                         help='disables macOS GPU training')
+parser.add_argument('--no-xpu', action='store_true',
+                        help='disables Intel XPU training')
 parser.add_argument('--seed', type=int, default=1, metavar='S',
                     help='random seed (default: 1)')
 parser.add_argument('--log-interval', type=int, default=10, metavar='N',
@@ -24,6 +26,7 @@ parser.add_argument('--log-interval', type=int, default=10, metavar='N',
 args = parser.parse_args()
 args.cuda = not args.no_cuda and torch.cuda.is_available()
 use_mps = not args.no_mps and torch.backends.mps.is_available()
+use_xpu = not args.no_xpu and torch.xpu.is_available()
 
 torch.manual_seed(args.seed)
 
@@ -31,8 +34,12 @@ if args.cuda:
     device = torch.device("cuda")
 elif use_mps:
     device = torch.device("mps")
+elif use_xpu:
+    device = torch.device("xpu")
 else:
     device = torch.device("cpu")
+
+print('Device to use: ', device)
 
 kwargs = {'num_workers': 1, 'pin_memory': True} if args.cuda else {}
 train_loader = torch.utils.data.DataLoader(


### PR DESCRIPTION
Refactor Imagenet example to utilize torch.accelerator API. torch.accelerator API allows to abstract some of the accelerator specifics in the user scripts. By leveraging this API, the code becomes more adaptable to various hardware accelerators.